### PR TITLE
Fix InputStreamAXT.readToString()

### DIFF
--- a/src/java/org/ligi/axt/extensions/InputStreamAXT.java
+++ b/src/java/org/ligi/axt/extensions/InputStreamAXT.java
@@ -9,6 +9,8 @@ import java.io.InputStreamReader;
 
 public class InputStreamAXT {
 
+    private static final int CHARACTER_READ_BUFFER_SIZE = 1024;
+
     private final InputStream inputStream;
 
     public InputStreamAXT(InputStream inputStream) {
@@ -29,15 +31,27 @@ public class InputStreamAXT {
 
     public String readToString() throws IOException {
         InputStreamReader is = new InputStreamReader(inputStream);
-        StringBuilder sb = new StringBuilder();
-        BufferedReader br = new BufferedReader(is);
-        String read = br.readLine();
-
-        while (read != null) {
-            sb.append(read);
-            read = br.readLine();
+        try {
+            return readFromInputStreamReaderToString(is);
+        } finally {
+            is.close();
         }
+    }
 
-        return sb.toString();
+    private String readFromInputStreamReaderToString(InputStreamReader is) throws IOException {
+        BufferedReader reader = new BufferedReader(is, CHARACTER_READ_BUFFER_SIZE);
+        try {
+            char[] buffer = new char[CHARACTER_READ_BUFFER_SIZE];
+            StringBuilder sb = new StringBuilder();
+
+            int len;
+            while ((len = reader.read(buffer)) >= 0) {
+                sb.append(buffer, 0, len);
+            }
+
+            return sb.toString();
+        } finally {
+            reader.close();
+        }
     }
 }

--- a/src/test/java/org/ligi/axt/test/TheInputStreamAXT.java
+++ b/src/test/java/org/ligi/axt/test/TheInputStreamAXT.java
@@ -28,4 +28,11 @@ public class TheInputStreamAXT {
         assertThat(STRING_PROBE).isEqualTo(AXT.at(file).readToString());
     }
 
+    @Test
+    public void should_read_to_string_correctly() throws IOException {
+        String readFromStream = AXT.at(new StringInputStream(STRING_PROBE)).readToString();
+
+        assertThat(readFromStream).isEqualTo(STRING_PROBE);
+    }
+
 }

--- a/src/test/java/org/ligi/axt/test/TheInputStreamAXT.java
+++ b/src/test/java/org/ligi/axt/test/TheInputStreamAXT.java
@@ -16,7 +16,8 @@ import static org.fest.assertions.Assertions.assertThat;
 @RunWith(RobolectricTestRunner.class)
 public class TheInputStreamAXT {
 
-    public static final String STRING_PROBE = "132QWE";
+    private static final String STRING_PROBE = "first line\nsecond line";
+
     private File ROOT = Environment.getExternalStorageDirectory();
 
     @Test


### PR DESCRIPTION
`BufferedReader.readLine()` doesn't return the line termination characters, so `InputStreamAXT.readToString()` failed for streams containing line breaks.
